### PR TITLE
update event dispatcher to version 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.6
   - 5.5
   - 5.5.9
-  - 5.4
 
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Concepts behind
 
 Requirements
 ---
- * PHP 5.4 or greater
+ * PHP 5.5.9 or greater
  * [Symfony's EventDispatcher](https://github.com/symfony/EventDispatcher)
  * Important: SQLite 3.8.5 up to 3.8.9 not supported! @see Issue #8
    * PHP versions bundled with incompatible SQLite libraries: 5.5.21 to 25 and 5.6.5 to 9

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "symfony/event-dispatcher": "~2"
+        "symfony/event-dispatcher": "~3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7|~4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9c7ef39aa369dff75d5af86edd949f9c",
-    "content-hash": "ff21f7d95b307c1fefa1a657f41c99e6",
+    "hash": "60910629ab4c3aef85cb93332981f0f1",
+    "content-hash": "3550ebba7ba4e70a61da14b10c953f5f",
     "packages": [
         {
             "name": "symfony/event-dispatcher",
-            "version": "2.8.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "78c468665c9568c3faaa9c416a7134308f2d85c3"
+                "reference": "e8f47a327c2f0fd5aa04fa60af2b693006ed7283"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/78c468665c9568c3faaa9c416a7134308f2d85c3",
-                "reference": "78c468665c9568c3faaa9c416a7134308f2d85c3",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e8f47a327c2f0fd5aa04fa60af2b693006ed7283",
+                "reference": "e8f47a327c2f0fd5aa04fa60af2b693006ed7283",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
-                "symfony/dependency-injection": "~2.6|~3.0.0",
-                "symfony/expression-language": "~2.6|~3.0.0",
-                "symfony/stopwatch": "~2.3|~3.0.0"
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -38,7 +38,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -65,7 +65,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:14:19"
+            "time": "2016-10-13 06:29:04"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
For newer PHP-Versions it is recommended to use newer versions of PHPUnit. This is not possible, when Dive is part of the project, because Dive requires event dispatcher in version 2 and PHPUnit requires event dispatcher in version 3.

So I tried to change the required version for event dispatcher of Dive. UnitTests are OK, except PHP 5.4, which is not supported by event dispatcher anymore (requires php >= 5.5.9)
